### PR TITLE
[Bug] Fix utxo selection to allow for an exact match on the needed satoshis

### DIFF
--- a/src/lib/distributeFunds.ts
+++ b/src/lib/distributeFunds.ts
@@ -45,10 +45,10 @@ const separateOutputs = (
     outputs: ITxOutput[]
 ): ISeparatedOutputs => {
     const receivers = outputs
-            .filter((output) => isTransactionReceiver(output)) as ITransactionReceiver[];
+        .filter((output) => isTransactionReceiver(output)) as ITransactionReceiver[];
     const opReturnScripts = outputs
-            .filter((output) => isOpReturnOutput(output))
-            .map((output) => createOpReturnScript(output as IOpReturnOutput));
+        .filter((output) => isOpReturnOutput(output))
+        .map((output) => createOpReturnScript(output as IOpReturnOutput));
 
     return { receivers, opReturnScripts };
 };
@@ -73,7 +73,7 @@ const getNecessaryUtxosAndChange = (
         // Additional cost per Utxo input is 148 sats
         satoshisNeeded += 148;
 
-        if (satoshisAvailable > satoshisNeeded) break;
+        if (satoshisAvailable >= satoshisNeeded) break;
     }
 
     let change = satoshisAvailable - satoshisNeeded;

--- a/src/lib/distributeFunds.ts
+++ b/src/lib/distributeFunds.ts
@@ -38,7 +38,7 @@ const calculateFee = (
 
     const opReturnByteCount = opReturnScripts.reduce((acc, script) => acc + script.byteLength, 0);
 
-    return Math.floor((byteCount + opReturnByteCount) * satsPerByte);
+    return Math.ceil((byteCount + opReturnByteCount) * satsPerByte);
 };
 
 const separateOutputs = (


### PR DESCRIPTION
The utxo selection code had an off by 1 error. This makes sure if you have exactly the right number of satoshis that it doesn't error and say you have an insufficient balance.

My linter also didn't like the formatting on a couple lines, if you want me to remove them from the PR let me know.